### PR TITLE
Fix work period lookup

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -20,7 +20,8 @@ export async function getWorkTimeForDate(date, settings, userId) {
       start: { lte: date },
       end: { gte: date },
     },
-    orderBy: { start: 'asc' },
+    // Use most recent matching period in case of overlaps
+    orderBy: { start: 'desc' },
   });
   if (periods.length > 0) {
     return periods[0].work_time_minutes;


### PR DESCRIPTION
## Summary
- select most recent work period in `getWorkTimeForDate`

## Testing
- `npm test` *(fails: Cannot find module 'node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_6846816740d88326bc80a0cd92719adc