### PR TITLE
fix: prisma migrate deploy fails without datasource.url in config

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -3,6 +3,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 
 export default defineConfig({
   datasource: {
+    url: process.env.DATABASE_URL,
     adapter: () => {
       const connectionString = process.env.DATABASE_URL;
       if (!connectionString) {


### PR DESCRIPTION
## Fix

`prisma migrate deploy` requires an explicit `url` in `prisma.config.ts`. The adapter alone is only used by `PrismaClient` at runtime — the CLI tools need a direct connection string.

**Added `url: process.env.DATABASE_URL` to the `datasource` block in `prisma.config.ts`.**

This was missed in #6 since `prisma generate` (tested locally) doesn't require the URL, but `prisma migrate deploy` (run in the container via `start.sh`) does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)